### PR TITLE
Release v0.0.2, allow multiple dependencies for LaTeX tasks and better parametrization.

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
   run:
     - python >=3.6
-    - pytask >=0.0.3
+    - pytask >=0.0.4
 
 test:
   requires:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -22,6 +22,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-tinytex@v1
       - uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ all releases are available on `Anaconda.org
 <https://anaconda.org/pytask/pytask-latex>`_.
 
 
-0.0.2 - 2020-07-21
+0.0.2 - 2020-07-22
 ------------------
 
 - :gh:`2` allowed LaTeX tasks to have more than one dependency and allows to parametrize

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,11 @@ all releases are available on `Anaconda.org
 0.0.2 - 2020-07-22
 ------------------
 
-- :gh:`2` allowed LaTeX tasks to have more than one dependency and allows to parametrize
+- :gh:`1` allowed LaTeX tasks to have more than one dependency and allows to parametrize
   over latex options and latex documents. It also prepares release v0.0.2.
 
 
 0.0.1 - 2020-07-20
 ------------------
 
-- :gh:`1` combined the whole effort which went into releasing v0.0.1.
+- Releases v0.0.1.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,13 @@ chronological order. Releases follow `semantic versioning <https://semver.org/>`
 all releases are available on `Anaconda.org <https://anaconda.org/pytask/pytask-latex>`_.
 
 
-0.0.1 - 2020-xx-xx
+0.0.2 - 2020-07-21
+------------------
+
+- :gh:`2` allowed LaTeX tasks to have more than one dependency.
+
+
+0.0.1 - 2020-07-20
 ------------------
 
 - :gh:`1` combined the whole effort which went into releasing v0.0.1.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,13 +3,15 @@ Changes
 
 This is a record of all past pytask-latex releases and what went into them in reverse
 chronological order. Releases follow `semantic versioning <https://semver.org/>`_ and
-all releases are available on `Anaconda.org <https://anaconda.org/pytask/pytask-latex>`_.
+all releases are available on `Anaconda.org
+<https://anaconda.org/pytask/pytask-latex>`_.
 
 
 0.0.2 - 2020-07-21
 ------------------
 
-- :gh:`2` allowed LaTeX tasks to have more than one dependency.
+- :gh:`2` allowed LaTeX tasks to have more than one dependency and allows to parametrize
+  over latex options and latex documents. It also prepares release v0.0.2.
 
 
 0.0.1 - 2020-07-20

--- a/README.rst
+++ b/README.rst
@@ -86,13 +86,50 @@ For example, to compile your document with XeLaTeX, use
 
 .. code-block:: python
 
-    @pytask.mark.latex("--xelatex", "--interaction=nonstopmode", "--synctex=1")
+    @pytask.mark.latex("--xelatex", "--interaction=nonstopmode")
     def task_compile_latex_document():
         pass
 
 The options ``jobname``, ``output-directory`` and the ``.tex`` file which will be
 compiled are handled by the ``@pytask.mark.depends_on`` and ``@pytask.mark.produces``
 markers and cannot be changed.
+
+
+Parametrization
+~~~~~~~~~~~~~~~
+
+You can also parametrize the compilation, meaning compiling multiple .tex documents
+as well as compiling a .tex document with different command line arguments.
+
+The following task compiles two latex documents.
+
+.. code-block:: python
+
+    @pytask.mark.latex
+    @pytask.mark.parametrize(
+        "depends_on, produces",
+        [("document_1.tex", "document_1.pdf"), ("document_2.tex", "document_2.pdf")],
+    )
+    def task_compile_latex_document():
+        pass
+
+
+If you want to compile the same document with different command line options, you have
+to include the latex decorator in the parametrization just like with
+``@pytask.mark.depends_on`` and ``@pytask.mark.produces``.
+
+.. code-block:: python
+
+    @pytask.mark.depends_on("document.tex")
+    @pytask.mark.parametrize(
+        "produces, latex",
+        [
+            ("document.pdf", ["--pdf", "interaction=nonstopmode"]),
+            ("document.dvi", ["--dvi", "interaction=nonstopmode"]),
+        ],
+    )
+    def task_compile_latex_document():
+        pass
 
 
 Changes

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,18 @@ Here is an example where you want to compile ``document.tex`` to a PDF.
         pass
 
 
+Note that, the first dependency is always assumed to be the LaTeX document. With
+multiple dependencies it may look like this
+
+.. code-block:: python
+
+    @pytask.mark.latex
+    @pytask.mark.depends_on("document.tex", "image.png")
+    @pytask.mark.produces("document.pdf")
+    def task_compile_latex_document():
+        pass
+
+
 To customize the compilation, you can pass some command line arguments to ``latexmk``
 via the ``@pytask.mark.latex`` marker. The default is the following.
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - conda-verify
 
   # Package dependencies
-  - pytask
+  - pytask >= 0.0.4
 
   # Misc
   - jupyterlab

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ serialize =
 
 [bumpversion:file:docs/conf.py]
 
-[bumpversion:file:src/parallel/__init__.py]
+[bumpversion:file:src/pytask_latex/__init__.py]

--- a/src/pytask_latex/collect.py
+++ b/src/pytask_latex/collect.py
@@ -10,16 +10,16 @@ from pytask.parametrize import _copy_func
 from pytask.shared import to_list
 
 
-def compile_latex_document(depends_on, produces, args):
+def compile_latex_document(depends_on, produces, latex):
     latex_document = to_list(depends_on)[0]
 
     if latex_document.stem != produces.stem:
-        args.append(f"--jobname={produces.stem}")
+        latex.append(f"--jobname={produces.stem}")
 
     subprocess.run(
         [
             "latexmk",
-            *args,
+            *latex,
             f"--output-directory={produces.parent.as_posix()}",
             f"{latex_document.as_posix()}",
         ]
@@ -43,7 +43,7 @@ def pytask_collect_task(session, path, name, obj):
         latex_function.pytestmark = copy.deepcopy(task.function.pytestmark)
 
         args = _create_command_line_arguments(task)
-        latex_function = functools.partial(latex_function, args=args)
+        latex_function = functools.partial(latex_function, latex=args)
 
         task.function = latex_function
 

--- a/src/pytask_latex/execute.py
+++ b/src/pytask_latex/execute.py
@@ -14,19 +14,18 @@ def pytask_execute_task_setup(task):
                 "your PATH."
             )
 
-        first_dep = task.depends_on[0]
         if not (
-            isinstance(first_dep, FilePathNode) and first_dep.value.suffix == ".tex"
+            isinstance(task.depends_on[0], FilePathNode)
+            and task.depends_on[0].value.suffix == ".tex"
         ):
             raise ValueError(
                 "The first or sole dependency must point to the .tex document which "
                 "will be compiled."
             )
 
-        first_prod = task.produces[0]
         if not (
-            isinstance(first_prod, FilePathNode)
-            and first_prod.value.suffix in [".pdf", ".ps", ".dvi"]
+            isinstance(task.produces[0], FilePathNode)
+            and task.produces[0].value.suffix in [".pdf", ".ps", ".dvi"]
         ):
             raise ValueError(
                 "The first or sole product must point to a .pdf, .ps or .dvi file "

--- a/src/pytask_latex/execute.py
+++ b/src/pytask_latex/execute.py
@@ -1,8 +1,8 @@
 import shutil
-from pathlib import Path
 
 import pytask
 from pytask.mark import get_markers_from_task
+from pytask.nodes import FilePathNode
 
 
 @pytask.hookimpl
@@ -14,8 +14,21 @@ def pytask_execute_task_setup(task):
                 "your PATH."
             )
 
-    if isinstance(task.depends_on, Path):
-        raise ValueError("'depends_on' must be a path to a single .tex document.")
+        first_dep = task.depends_on[0]
+        if not (
+            isinstance(first_dep, FilePathNode) and first_dep.value.suffix == ".tex"
+        ):
+            raise ValueError(
+                "The first or sole dependency must point to the .tex document which "
+                "will be compiled."
+            )
 
-    if isinstance(task.produces, Path):
-        raise ValueError("'produces' must be a path to a single .pdf document.")
+        first_prod = task.produces[0]
+        if not (
+            isinstance(first_prod, FilePathNode)
+            and first_prod.value.suffix in [".pdf", ".ps", ".dvi"]
+        ):
+            raise ValueError(
+                "The first or sole product must point to a .pdf, .ps or .dvi file "
+                "which is the compilation."
+            )

--- a/src/pytask_latex/parametrize.py
+++ b/src/pytask_latex/parametrize.py
@@ -1,0 +1,8 @@
+import pytask
+
+
+@pytask.hookimpl
+def pytask_generate_tasks_add_marker(obj, kwargs):
+    if callable(obj):
+        if "latex" in kwargs:
+            pytask.mark.__getattr__("latex")(*kwargs.pop("latex"))(obj)

--- a/src/pytask_latex/plugin.py
+++ b/src/pytask_latex/plugin.py
@@ -1,9 +1,11 @@
 import pytask
 from pytask_latex import collect
 from pytask_latex import execute
+from pytask_latex import parametrize
 
 
 @pytask.hookimpl
 def pytask_add_hooks(pm):
     pm.register(collect)
     pm.register(execute)
+    pm.register(parametrize)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,6 @@ needs_latexmk = pytest.mark.skipif(
 )
 
 skip_on_github_actions_with_win = pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS", False) and sys.platform == "win32",
+    os.environ.get("GITHUB_ACTIONS", "false") == "true" and sys.platform == "win32",
     reason="TinyTeX does not work on Windows.",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,13 @@
+import os
 import shutil
+import sys
 
 import pytest
 
 needs_latexmk = pytest.mark.skipif(
     shutil.which("latexmk") is None, reason="latexmk needs to be installed."
+)
+
+skip_on_github_actions_with_win = pytest.mark.skipif(
+    os.environ.get("GITHUB_ACTIONS", False) and sys.platform == "win32"
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import shutil
+
+import pytest
+
+needs_latexmk = pytest.mark.skipif(
+    shutil.which("latexmk") is None, reason="latexmk needs to be installed."
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,5 +9,6 @@ needs_latexmk = pytest.mark.skipif(
 )
 
 skip_on_github_actions_with_win = pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS", False) and sys.platform == "win32"
+    os.environ.get("GITHUB_ACTIONS", False) and sys.platform == "win32",
+    reason="TinyTeX does not work on Windows.",
 )

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,15 +1,66 @@
-import shutil
 import textwrap
+from contextlib import ExitStack as does_not_raise  # noqa: N813
+from pathlib import Path
 
 import pytest
+from conftest import needs_latexmk
 from pytask.main import main
+from pytask.mark import Mark
+from pytask.nodes import FilePathNode
+from pytask_latex.execute import pytask_execute_task_setup
 
 
-pytestmark = pytest.mark.skipif(
-    shutil.which("latexmk") is None, reason="latexmk needs to be installed."
+class DummyTask:
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "depends_on, produces, expectation",
+    [
+        (
+            [FilePathNode("a", Path("a.tex"))],
+            [FilePathNode("a", Path("a.pdf"))],
+            does_not_raise(),
+        ),
+        (
+            [FilePathNode("a", Path("a.txt")), FilePathNode("b", Path("b.pdf"))],
+            [FilePathNode("a", Path("a.pdf"))],
+            pytest.raises(ValueError),
+        ),
+        (
+            [FilePathNode("a", Path("a.tex"))],
+            [FilePathNode("a", Path("a.dvi"))],
+            does_not_raise(),
+        ),
+        (
+            [FilePathNode("a", Path("a.tex"))],
+            [FilePathNode("a", Path("a.ps"))],
+            does_not_raise(),
+        ),
+        (
+            [FilePathNode("a", Path("a.tex"))],
+            [FilePathNode("a", Path("a.txt"))],
+            pytest.raises(ValueError),
+        ),
+        (
+            [FilePathNode("a", Path("a.tex"))],
+            [FilePathNode("a", Path("a.txt")), FilePathNode("b", Path("b.pdf"))],
+            pytest.raises(ValueError),
+        ),
+    ],
 )
+def test_pytask_execute_task_setup_dependency(depends_on, produces, expectation):
+    task = DummyTask()
+    task.depends_on = depends_on
+    task.produces = produces
+    task.markers = [Mark("latex", (), {})]
+
+    with expectation:
+        pytask_execute_task_setup(task)
 
 
+@needs_latexmk
 @pytest.mark.end_to_end
 def test_compile_latex_document(tmp_path):
     task_source = """
@@ -38,6 +89,7 @@ def test_compile_latex_document(tmp_path):
     assert tmp_path.joinpath("document.pdf").exists()
 
 
+@needs_latexmk
 @pytest.mark.end_to_end
 def test_compile_latex_document_to_different_name(tmp_path):
     task_source = """
@@ -66,13 +118,14 @@ def test_compile_latex_document_to_different_name(tmp_path):
     assert tmp_path.joinpath("out.pdf").exists()
 
 
+@needs_latexmk
 @pytest.mark.end_to_end
 def test_compile_w_bibiliography(tmp_path):
     task_source = """
     import pytask
 
     @pytask.mark.latex
-    @pytask.mark.depends_on("in_w_bib.tex")
+    @pytask.mark.depends_on(["in_w_bib.tex", "bib.bib"])
     @pytask.mark.produces("out_w_bib.pdf")
     def task_compile_document():
         pass
@@ -106,6 +159,7 @@ def test_compile_w_bibiliography(tmp_path):
     assert tmp_path.joinpath("out_w_bib.pdf").exists()
 
 
+@needs_latexmk
 @pytest.mark.end_to_end
 def test_raise_error_if_latexmk_is_not_found(tmp_path, monkeypatch):
     task_source = """
@@ -138,6 +192,7 @@ def test_raise_error_if_latexmk_is_not_found(tmp_path, monkeypatch):
     assert isinstance(session.execution_reports[0].exc_info[1], RuntimeError)
 
 
+@needs_latexmk
 @pytest.mark.end_to_end
 def test_compile_latex_document_w_xelatex(tmp_path):
     task_source = """
@@ -166,6 +221,8 @@ def test_compile_latex_document_w_xelatex(tmp_path):
     assert tmp_path.joinpath("document.pdf").exists()
 
 
+@needs_latexmk
+@pytest.mark.end_to_end
 def test_compile_latex_document_w_two_dependencies(tmp_path):
     task_source = """
     import pytask
@@ -195,6 +252,8 @@ def test_compile_latex_document_w_two_dependencies(tmp_path):
     assert tmp_path.joinpath("document.pdf").exists()
 
 
+@needs_latexmk
+@pytest.mark.end_to_end
 def test_fail_because_latex_document_is_not_first_dependency(tmp_path):
     task_source = """
     import pytask

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from conftest import needs_latexmk
+from conftest import skip_on_github_actions_with_win
 from pytask.main import main
 from pytask.mark import Mark
 from pytask.nodes import FilePathNode
@@ -64,6 +65,7 @@ def test_pytask_execute_task_setup(monkeypatch, depends_on, produces, expectatio
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_compile_latex_document(tmp_path):
     task_source = """
@@ -93,6 +95,7 @@ def test_compile_latex_document(tmp_path):
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_compile_latex_document_to_different_name(tmp_path):
     task_source = """
@@ -122,6 +125,7 @@ def test_compile_latex_document_to_different_name(tmp_path):
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_compile_w_bibiliography(tmp_path):
     task_source = """
@@ -163,6 +167,7 @@ def test_compile_w_bibiliography(tmp_path):
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_raise_error_if_latexmk_is_not_found(tmp_path, monkeypatch):
     task_source = """
@@ -196,6 +201,7 @@ def test_raise_error_if_latexmk_is_not_found(tmp_path, monkeypatch):
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_compile_latex_document_w_xelatex(tmp_path):
     task_source = """
@@ -225,6 +231,7 @@ def test_compile_latex_document_w_xelatex(tmp_path):
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_compile_latex_document_w_two_dependencies(tmp_path):
     task_source = """
@@ -256,6 +263,7 @@ def test_compile_latex_document_w_two_dependencies(tmp_path):
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_fail_because_latex_document_is_not_first_dependency(tmp_path):
     task_source = """

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -67,40 +67,6 @@ def test_compile_latex_document_to_different_name(tmp_path):
 
 
 @pytest.mark.end_to_end
-def test_parametrized_compilation_of_latex_document(tmp_path):
-    task_source = """
-    import pytask
-
-    @pytask.mark.latex
-    @pytask.mark.parametrize("depends_on, produces", [
-        ("document_1.tex", "document_1.pdf"),
-        ("document_2.tex", "document_2.pdf"),
-    ])
-    def task_compile_latex_document():
-        pass
-    """
-    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(task_source))
-
-    for name, content in [
-        ("document_1.tex", "Like a worn out recording"),
-        ("document_2.tex", "Of a favorite song"),
-    ]:
-        latex_source = fr"""
-        \documentclass{{report}}
-        \begin{{document}}
-        {content}
-        \end{{document}}
-        """
-        tmp_path.joinpath(name).write_text(textwrap.dedent(latex_source))
-
-    session = main({"paths": tmp_path})
-
-    assert session.exit_code == 0
-    assert tmp_path.joinpath("document_1.pdf").exists()
-    assert tmp_path.joinpath("document_2.pdf").exists()
-
-
-@pytest.mark.end_to_end
 def test_compile_w_bibiliography(tmp_path):
     task_source = """
     import pytask

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -50,7 +50,12 @@ class DummyTask:
         ),
     ],
 )
-def test_pytask_execute_task_setup_dependency(depends_on, produces, expectation):
+def test_pytask_execute_task_setup_dependency(
+    monkeypatch, depends_on, produces, expectation
+):
+    # Act like latexmk is installed since we do not test this.
+    monkeypatch.setattr("pytask_latex.execute.shutil.which", lambda x: True)
+
     task = DummyTask()
     task.depends_on = depends_on
     task.produces = produces

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -50,9 +50,7 @@ class DummyTask:
         ),
     ],
 )
-def test_pytask_execute_task_setup_dependency(
-    monkeypatch, depends_on, produces, expectation
-):
+def test_pytask_execute_task_setup(monkeypatch, depends_on, produces, expectation):
     # Act like latexmk is installed since we do not test this.
     monkeypatch.setattr("pytask_latex.execute.shutil.which", lambda x: True)
 

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -2,6 +2,7 @@ import textwrap
 
 import pytest
 from conftest import needs_latexmk
+from conftest import skip_on_github_actions_with_win
 from pytask.main import main
 from pytask_latex.parametrize import pytask_generate_tasks_add_marker
 
@@ -29,6 +30,7 @@ def test_pytask_generate_tasks_add_marker(obj, kwargs, expected):
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_parametrized_compilation_of_latex_documents(tmp_path):
     task_source = """
@@ -64,6 +66,7 @@ def test_parametrized_compilation_of_latex_documents(tmp_path):
 
 
 @needs_latexmk
+@skip_on_github_actions_with_win
 @pytest.mark.end_to_end
 def test_parametrizing_latex_options(tmp_path):
     task_source = """

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -1,0 +1,67 @@
+import textwrap
+
+import pytest
+from pytask.main import main
+
+
+@pytest.mark.end_to_end
+def test_parametrized_compilation_of_latex_documents(tmp_path):
+    task_source = """
+    import pytask
+
+    @pytask.mark.latex
+    @pytask.mark.parametrize("depends_on, produces", [
+        ("document_1.tex", "document_1.pdf"),
+        ("document_2.tex", "document_2.pdf"),
+    ])
+    def task_compile_latex_document():
+        pass
+    """
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(task_source))
+
+    for name, content in [
+        ("document_1.tex", "Like a worn out recording"),
+        ("document_2.tex", "Of a favorite song"),
+    ]:
+        latex_source = fr"""
+        \documentclass{{report}}
+        \begin{{document}}
+        {content}
+        \end{{document}}
+        """
+        tmp_path.joinpath(name).write_text(textwrap.dedent(latex_source))
+
+    session = main({"paths": tmp_path})
+
+    assert session.exit_code == 0
+    assert tmp_path.joinpath("document_1.pdf").exists()
+    assert tmp_path.joinpath("document_2.pdf").exists()
+
+
+@pytest.mark.end_to_end
+def test_parametrizing_latex_options(tmp_path):
+    task_source = """
+    import pytask
+
+    @pytask.mark.parametrize("depends_on, produces, latex", [
+        ("document.tex", "document.pdf", ("--interaction=nonstopmode", "--pdf")),
+        ("document.tex", "document.dvi", ("--interaction=nonstopmode", "--dvi")),
+    ])
+    def task_compile_latex_document():
+        pass
+    """
+    tmp_path.joinpath("task_dummy.py").write_text(textwrap.dedent(task_source))
+
+    latex_source = r"""
+    \documentclass{report}
+    \begin{document}
+    I can't stop this feeling. Deep inside of me.
+    \end{document}
+    """
+    tmp_path.joinpath("document.tex").write_text(textwrap.dedent(latex_source))
+
+    session = main({"paths": tmp_path})
+
+    assert session.exit_code == 0
+    assert tmp_path.joinpath("document.pdf").exists()
+    assert tmp_path.joinpath("document.dvi").exists()

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -1,7 +1,13 @@
+import shutil
 import textwrap
 
 import pytest
 from pytask.main import main
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("latexmk") is None, reason="latexmk needs to be installed."
+)
 
 
 @pytest.mark.end_to_end

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -1,15 +1,34 @@
-import shutil
 import textwrap
 
 import pytest
+from conftest import needs_latexmk
 from pytask.main import main
+from pytask_latex.parametrize import pytask_generate_tasks_add_marker
 
 
-pytestmark = pytest.mark.skipif(
-    shutil.which("latexmk") is None, reason="latexmk needs to be installed."
+def func():
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "obj, kwargs, expected",
+    [(len, {}, None), (func, {"latex": ["--dummy-option"]}, func), (func, {}, None)],
 )
+def test_pytask_generate_tasks_add_marker(obj, kwargs, expected):
+    pytask_generate_tasks_add_marker(obj, kwargs)
+
+    if expected is None:
+        assert not hasattr(obj, "pytestmark")
+    else:
+        assert obj.pytestmark
+
+    # Cleanup necessary since func is changed in-place.
+    if hasattr(obj, "pytestmark"):
+        delattr(obj, "pytestmark")
 
 
+@needs_latexmk
 @pytest.mark.end_to_end
 def test_parametrized_compilation_of_latex_documents(tmp_path):
     task_source = """
@@ -44,6 +63,7 @@ def test_parametrized_compilation_of_latex_documents(tmp_path):
     assert tmp_path.joinpath("document_2.pdf").exists()
 
 
+@needs_latexmk
 @pytest.mark.end_to_end
 def test_parametrizing_latex_options(tmp_path):
     task_source = """

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ basepython = python
 
 [testenv:pytest]
 conda_deps =
-    pytask >=0.0.3
+    pytask >=0.0.4
     pytest
     pytest-cov
     pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 skip_missing_interpreters = True
 
 [testenv]
+passenv = GITHUB_ACTIONS
 basepython = python
 
 [testenv:pytest]


### PR DESCRIPTION
#### Changes

LaTeX tasks could not handle more than one dependency. Now, the first dependency has to be the ``.tex`` file, but all others are normal dependencies. Furthermore, you can parametrize tasks over latex documents and options.

And `tinytex` allows to test compilation with Github actions.