### PR TITLE
fix: use hyphenated distribution name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
-name = "pytask_latex"
+name = "pytask-latex"
 description = "Compile LaTeX documents with pytask."
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

- Change the project distribution name from `pytask_latex` to `pytask-latex` in `pyproject.toml`.
- Keep the import package and pytask plugin entry point as `pytask_latex`.

## Why

PyPI displays the distribution name from package metadata in the install command. Python packaging normalizes underscores and hyphens to the same project key, but using the hyphenated distribution name keeps PyPI aligned with the README, repository name, and installation instructions.

## Validation

- rebased onto fetched `origin/main`
- `uv build`
- inspected generated wheel metadata: `Name: pytask-latex`
